### PR TITLE
added optional --user argument to IRkernel::installspec()

### DIFF
--- a/R/kernel.r
+++ b/R/kernel.r
@@ -200,7 +200,7 @@ main <- function(connection_file="") {
 #'
 #'@param user Install into user directory ~/.ipython or globally?
 #'@export
-installspec <- function(user=F) {
+installspec <- function(user=T) {
     srcdir = system.file("kernelspec", package="IRkernel")
     user_flag=ifelse(user, "--user", "")
     cmd = paste("ipython kernelspec install --replace --name ir", user_flag, srcdir, sep=" ")

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -198,9 +198,11 @@ main <- function(connection_file="") {
 
 #'Install the kernelspec to tell IPython (>= 3) about IRkernel
 #'
+#'@param user Install into user directory ~/.ipython or globally?
 #'@export
-installspec <- function() {
+installspec <- function(user=F) {
     srcdir = system.file("kernelspec", package="IRkernel")
-    cmd = paste("ipython kernelspec install --replace --name ir", srcdir, sep=" ")
+    user_flag=ifelse(user, "--user", "")
+    cmd = paste("ipython kernelspec install --replace --name ir", user_flag, srcdir, sep=" ")
     system(cmd, wait=TRUE)
 }


### PR DESCRIPTION
On my system, the call to 

~~~R
IRkernel::installspec()
~~~

failed with `Permission denied` because `ipython kernelspec install` installs the kernel globally by default. I added an option `user` which allows to pass the `--user` flag to the call to `ipython kernelspec install`.